### PR TITLE
Support the batch operation

### DIFF
--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -277,7 +277,7 @@ describe('instantiate azure client', () => {
 describe('azure request building', () => {
   const client = new AzureOpenAI({ baseURL: 'https://example.com', apiKey: 'My API Key', apiVersion });
 
-  describe.only('model to deployment mapping', function () {
+  describe('model to deployment mapping', function () {
     const testFetch = async (url: RequestInfo): Promise<Response> => {
       return new Response(JSON.stringify({ url }), { headers: { 'content-type': 'application/json' } });
     };

--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -4,6 +4,8 @@ import { Headers } from 'openai/core';
 import defaultFetch, { Response, type RequestInit, type RequestInfo } from 'node-fetch';
 
 const apiVersion = '2024-02-15-preview';
+const deployment = 'deployment';
+const model = 'unused model';
 
 describe('instantiate azure client', () => {
   const env = process.env;
@@ -274,6 +276,278 @@ describe('instantiate azure client', () => {
 
 describe('azure request building', () => {
   const client = new AzureOpenAI({ baseURL: 'https://example.com', apiKey: 'My API Key', apiVersion });
+
+  describe.only('model to deployment mapping', function () {
+    const testFetch = async (url: RequestInfo): Promise<Response> => {
+      return new Response(JSON.stringify({ url }), { headers: { 'content-type': 'application/json' } });
+    };
+    describe('with client-level deployment', function () {
+      const client = new AzureOpenAI({
+        endpoint: 'https://example.com',
+        apiKey: 'My API Key',
+        apiVersion,
+        deployment,
+        fetch: testFetch,
+      });
+
+      test('handles Batch', async () => {
+        expect(
+          await client.batches.create({
+            completion_window: '24h',
+            endpoint: '/v1/chat/completions',
+            input_file_id: 'file-id',
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/deployments/${deployment}/batches?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles completions', async () => {
+        expect(
+          await client.completions.create({
+            model,
+            prompt: 'prompt',
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/deployments/${deployment}/completions?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles chat completions', async () => {
+        expect(
+          await client.chat.completions.create({
+            model,
+            messages: [{ role: 'system', content: 'Hello' }],
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/deployments/${deployment}/chat/completions?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles embeddings', async () => {
+        expect(
+          await client.embeddings.create({
+            model,
+            input: 'input',
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/deployments/${deployment}/embeddings?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles audio translations', async () => {
+        expect(
+          await client.audio.translations.create({
+            model,
+            file: { url: 'https://example.com', blob: () => 0 as any },
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/deployments/${deployment}/audio/translations?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles audio transcriptions', async () => {
+        expect(
+          await client.audio.transcriptions.create({
+            model,
+            file: { url: 'https://example.com', blob: () => 0 as any },
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/deployments/${deployment}/audio/transcriptions?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles text to speech', async () => {
+        expect(
+          await (
+            await client.audio.speech.create({
+              model,
+              input: '',
+              voice: 'alloy',
+            })
+          ).json(),
+        ).toStrictEqual({
+          url: `https://example.com/openai/deployments/${deployment}/audio/speech?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles image generation', async () => {
+        expect(
+          await client.images.generate({
+            model,
+            prompt: 'prompt',
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/deployments/${deployment}/images/generations?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles assistants', async () => {
+        expect(
+          await client.beta.assistants.create({
+            model,
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/assistants?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles files', async () => {
+        expect(
+          await client.files.create({
+            file: { url: 'https://example.com', blob: () => 0 as any },
+            purpose: 'assistants',
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/files?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles fine tuning', async () => {
+        expect(
+          await client.fineTuning.jobs.create({
+            model,
+            training_file: '',
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/fine_tuning/jobs?api-version=${apiVersion}`,
+        });
+      });
+    });
+
+    describe('with no client-level deployment', function () {
+      const client = new AzureOpenAI({
+        endpoint: 'https://example.com',
+        apiKey: 'My API Key',
+        apiVersion,
+        fetch: testFetch,
+      });
+
+      test('Batch is not handled', async () => {
+        expect(
+          await client.batches.create({
+            completion_window: '24h',
+            endpoint: '/v1/chat/completions',
+            input_file_id: 'file-id',
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/batches?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles completions', async () => {
+        expect(
+          await client.completions.create({
+            model: deployment,
+            prompt: 'prompt',
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/deployments/${deployment}/completions?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles chat completions', async () => {
+        expect(
+          await client.chat.completions.create({
+            model: deployment,
+            messages: [{ role: 'system', content: 'Hello' }],
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/deployments/${deployment}/chat/completions?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles embeddings', async () => {
+        expect(
+          await client.embeddings.create({
+            model: deployment,
+            input: 'input',
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/deployments/${deployment}/embeddings?api-version=${apiVersion}`,
+        });
+      });
+
+      test('Audio translations is not handled', async () => {
+        expect(
+          await client.audio.translations.create({
+            model: deployment,
+            file: { url: 'https://example.com', blob: () => 0 as any },
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/audio/translations?api-version=${apiVersion}`,
+        });
+      });
+
+      test('Audio transcriptions is not handled', async () => {
+        expect(
+          await client.audio.transcriptions.create({
+            model: deployment,
+            file: { url: 'https://example.com', blob: () => 0 as any },
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/audio/transcriptions?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles text to speech', async () => {
+        expect(
+          await (
+            await client.audio.speech.create({
+              model: deployment,
+              input: '',
+              voice: 'alloy',
+            })
+          ).json(),
+        ).toStrictEqual({
+          url: `https://example.com/openai/deployments/${deployment}/audio/speech?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles image generation', async () => {
+        expect(
+          await client.images.generate({
+            model: deployment,
+            prompt: 'prompt',
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/deployments/${deployment}/images/generations?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles assistants', async () => {
+        expect(
+          await client.beta.assistants.create({
+            model,
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/assistants?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles files', async () => {
+        expect(
+          await client.files.create({
+            file: { url: 'https://example.com', blob: () => 0 as any },
+            purpose: 'assistants',
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/files?api-version=${apiVersion}`,
+        });
+      });
+
+      test('handles fine tuning', async () => {
+        expect(
+          await client.fineTuning.jobs.create({
+            model,
+            training_file: '',
+          }),
+        ).toStrictEqual({
+          url: `https://example.com/openai/fine_tuning/jobs?api-version=${apiVersion}`,
+        });
+      });
+    });
+  });
 
   describe('Content-Length', () => {
     test('handles multi-byte characters', () => {


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Update the Azure client to support the batch operation.

## Additional context & links
The Azure client dynamically updates the path of deployment-based operations to include the deployment name. The deployment name can be supplied to the client in two ways, through the client constructor's `deployment` option, or through the `model` property in the request. However, the `model` property is not accessed in all requests. For example, the audio requests are multi part form data that are streamed and it is not straightforward to access properties on them. This can be remedied by overloading these methods to access the `model` property before the request is transformed but perhaps it is not worth the effort. Another example is the batch API where there is no `model` in the request to begin with.

The client behavior can be summarized as follows:
- It is aligned with that of Python's where client-level's `deployment` takes precedence over request-level's `model`.
- If a client-level's `deployment` is not supplied, and a call is made to batches, audio translations, or audio transcriptions, the request path won't include a deployment name. The service in this case will return an error response.